### PR TITLE
[JENKINS-58207] Update Waffle and JNA to work with Jenkins 2.181+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,11 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.150.2</jenkins.version>
+    <jenkins.version>2.181</jenkins.version>
     <java.level>8</java.level>
-    <waffle.version>1.9.0</waffle.version>
+    <waffle.version>2.0.0</waffle.version>
+    <jna.version>5.3.1</jna.version>
+    <slf4j.version>2.0.0-alpha0</slf4j.version><!-- Upgraded over jenkins requirement because of Waffle -->
   </properties>
 
   <artifactId>NegotiateSSO</artifactId>
@@ -53,6 +55,31 @@
       <groupId>com.github.waffle</groupId>
       <artifactId>waffle-jna</artifactId>
       <version>${waffle.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version><!-- which version of Jenkins plugin pom is this plugin built against? -->
+    <version>3.50</version><!-- which version of Jenkins plugin pom is this plugin built against? -->
     <relativePath />
   </parent>
 

--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
@@ -105,12 +105,6 @@ public class NegSecUserSeedFilter implements Filter {
      */
     @SuppressRestrictedWarnings(UserSeedProperty.class)
     private void populateUserSeed(HttpServletRequest httpRequest, String username) {
-        VersionNumber current = Jenkins.getVersion();
-        if (current == null || current.isNewerThan(new VersionNumber("2.150.99")) && current.isOlderThan(new VersionNumber("2.160"))) {
-            // We have to depend on API introduced in 2.150.2 and 1.160 hence we need to skip this for ["2.151", "2.159"]
-            return;
-        }
-
         // Adapted from hudson.security.AuthenticationProcessingFilter2
         if (!UserSeedProperty.DISABLE_USER_SEED) {
             User user = User.getById(username, true);


### PR DESCRIPTION
Jenkins release 2.181 updated the dependency on JNA, but does not depend on JNA-Platform. With NegotiateSSO, JNA 5.3.1 was being loaded along with JNA-Platform 4.5.1 (required by Waffle).

This pull request includes the following:
* Update Waffle-JNA from 1.9.0 to 2.0.0
* Directly specify the dependency on JNA and JNA-Platform, 5.3.1
* Adds a dependency on slf4j 2.0.0-alpha0 (only because Waffle-JNA depends on it...)
* Upgrades the parent POM reference to 3.50
* Upgrade the minimum Jenkins version to 2.181 (because I couldn't get this update to work at all with older versions)
* Removes a no-longer-needed version check in code.

See [JENKINS-58207](https://issues.jenkins-ci.org/browse/JENKINS-58207).
