### PR TITLE
Fix the GitHub Actions runner type

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into the default branch
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Fix the build under GitHub Actions - this plugin is Windows-specific, and does not pass tests on linux.
