### PR TITLE
Replace all usages of Acegi Security types with the appropriate Spring Security types

### DIFF
--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecFilter.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecFilter.java
@@ -47,7 +47,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.acegisecurity.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.common.annotations.VisibleForTesting;
 import jenkins.model.Jenkins;

--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
@@ -45,9 +45,9 @@ import waffle.servlet.WindowsPrincipal;
 import jenkins.model.Jenkins;
 import jenkins.security.SecurityListener;
 import jenkins.security.seed.UserSeedProperty;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
-import org.acegisecurity.userdetails.UserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 /**
@@ -85,12 +85,12 @@ public class NegSecUserSeedFilter implements Filter {
         }
         Jenkins jenkins = Jenkins.get();
         SecurityRealm realm = jenkins.getSecurityRealm();
-        UserDetails userDetails = realm.loadUserByUsername(principalName);
+        UserDetails userDetails = realm.loadUserByUsername2(principalName);
         Authentication authToken = new UsernamePasswordAuthenticationToken(
                         userDetails.getUsername(),
                         userDetails.getPassword(),
                         userDetails.getAuthorities());
-        ACL.as(authToken);
+        ACL.as2(authToken);
         populateUserSeed(httpRequest, userDetails.getUsername());              
         SecurityListener.fireLoggedIn(userDetails.getUsername());
     }


### PR DESCRIPTION
Jenkins 2.266 replaced Acegi Security with Spring Security, and while the plugin still worked, it's time to change over to Spring Security
