### PR TITLE
Update Waffle-JNA to 3.1.1, which includes a security update for log4j/logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,9 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/negotiatesso-plugin</gitHubRepo>
-    <jenkins.version>2.274</jenkins.version><!-- First version of Jenkins running JNA 5.6.0 -->
+    <jenkins.version>2.321</jenkins.version><!-- First version of Jenkins running JNA 5.10.0 -->
     <java.level>8</java.level>
-    <waffle.version>3.0.0</waffle.version>
-    <jna.version>5.6.0</jna.version>
-    <slf4j.version>2.0.0-alpha1</slf4j.version><!-- Upgraded over jenkins requirement because of Waffle -->
+    <waffle.version>3.1.1</waffle.version>
   </properties>
 
   <artifactId>NegotiateSSO</artifactId>
@@ -57,31 +55,6 @@
       <groupId>com.github.waffle</groupId>
       <artifactId>waffle-jna</artifactId>
       <version>${waffle.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>${jna.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna-platform</artifactId>
-      <version>${jna.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Also bump baseline to Jenkins 2.321 to match JNA version
