### PR TITLE
Replace usages of deprecated types and methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/negotiatesso-plugin</gitHubRepo>
-    <jenkins.version>2.181</jenkins.version>
+    <jenkins.version>2.266</jenkins.version>
     <java.level>8</java.level>
     <waffle.version>2.0.0</waffle.version>
     <jna.version>5.3.1</jna.version>

--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecFilter.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecFilter.java
@@ -47,7 +47,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.acegisecurity.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.common.annotations.VisibleForTesting;
 import jenkins.model.Jenkins;

--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/NegSecUserSeedFilter.java
@@ -45,9 +45,9 @@ import waffle.servlet.WindowsPrincipal;
 import jenkins.model.Jenkins;
 import jenkins.security.SecurityListener;
 import jenkins.security.seed.UserSeedProperty;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
-import org.acegisecurity.userdetails.UserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 /**
@@ -85,12 +85,12 @@ public class NegSecUserSeedFilter implements Filter {
         }
         Jenkins jenkins = Jenkins.get();
         SecurityRealm realm = jenkins.getSecurityRealm();
-        UserDetails userDetails = realm.loadUserByUsername(principalName);
+        UserDetails userDetails = realm.loadUserByUsername2(principalName);
         Authentication authToken = new UsernamePasswordAuthenticationToken(
                         userDetails.getUsername(),
                         userDetails.getPassword(),
                         userDetails.getAuthorities());
-        ACL.as(authToken);
+        ACL.as2(authToken);
         populateUserSeed(httpRequest, userDetails.getUsername());              
         SecurityListener.fireLoggedIn(userDetails.getUsername());
     }

--- a/src/test/java/com/github/farmgeek4life/jenkins/negotiatesso/NegotiateConfigTests.java
+++ b/src/test/java/com/github/farmgeek4life/jenkins/negotiatesso/NegotiateConfigTests.java
@@ -35,6 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule.Step;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -69,12 +70,10 @@ public class NegotiateConfigTests {
      */
     @Test
     public void testNegotiateHasConfigPage() {
-        rule.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
-                HtmlElement enabled = currentPage.getElementByName("_.enabled");
-                assertNotNull("Negotiate configuration page missing.", enabled);
-            }
+        rule.then(r -> {
+            HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
+            HtmlElement enabled = currentPage.getElementByName("_.enabled");
+            assertNotNull("Negotiate configuration page missing.", enabled);            
         });
 
     }
@@ -84,13 +83,11 @@ public class NegotiateConfigTests {
      */
     @Test
     public void testEnableNegotiate() {
-        rule.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
-                HtmlElement enabled = currentPage.getElementByName("_.enabled");
-                enabled.fireEvent("click");
-                assertNotNull("Optional block wasn't expanded.", currentPage.getElementByName("_.redirectEnabled"));
-            }
+        rule.then(r -> {
+            HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
+            HtmlElement enabled = currentPage.getElementByName("_.enabled");
+            enabled.fireEvent("click");
+            assertNotNull("Optional block wasn't expanded.", currentPage.getElementByName("_.redirectEnabled"));
         });
     }
 
@@ -100,32 +97,30 @@ public class NegotiateConfigTests {
      */
     @Test
     public void testIfConfigCanBeUpdated() throws Exception {
-        rule.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                assertFalse("Plugin already enabled", NegotiateSSO.getInstance().getEnabled());
-                
-                HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
-                HtmlForm form = currentPage.getFormByName("config");
-                assertNotNull(form);
+        rule.then(r -> {
+            assertFalse("Plugin already enabled", NegotiateSSO.getInstance().getEnabled());
 
-                form.getInputByName("_.enabled").click();
-                form.getSelectByName("_.principalFormat").setSelectedAttribute("both", true);
-                form.getSelectByName("_.roleFormat").setSelectedAttribute("sid", true);
+            HtmlPage currentPage = rule.j.createWebClient().goTo("configureSecurity");
+            HtmlForm form = currentPage.getFormByName("config");
+            assertNotNull(form);
 
-                try {
-                    rule.j.submit(form);
-                    // CS IGNORE EmptyBlock FOR NEXT 3 LINES. REASON: Mocks Tests.
-                } catch (FailingHttpStatusCodeException e) {
-                    // Expected since filter cannot be added to Jenkins rule.
-                }
+            form.getInputByName("_.enabled").click();
+            form.getSelectByName("_.principalFormat").setSelectedAttribute("both", true);
+            form.getSelectByName("_.roleFormat").setSelectedAttribute("sid", true);
 
-                boolean wasEnabled = NegotiateSSO.getInstance().getEnabled();
-                if (IsWindowsOS()) {
-                    assertTrue("Plugin wasn't enabled after saving the new config", wasEnabled);
-                }
-                else {
-                    assertFalse("Plugin was enabled on a non-Windows OS", wasEnabled);
-                }
+            try {
+                rule.j.submit(form);
+                // CS IGNORE EmptyBlock FOR NEXT 3 LINES. REASON: Mocks Tests.
+            } catch (FailingHttpStatusCodeException e) {
+                // Expected since filter cannot be added to Jenkins rule.
+            }
+
+            boolean wasEnabled = NegotiateSSO.getInstance().getEnabled();
+            if (IsWindowsOS()) {
+                assertTrue("Plugin wasn't enabled after saving the new config", wasEnabled);
+            }
+            else {
+                assertFalse("Plugin was enabled on a non-Windows OS", wasEnabled);
             }
         });
     }


### PR DESCRIPTION
Replace usages of types that are deprecated (Acegi Security to Spring Security), as well the the usage of methods that are deprecated (from the Jenkins test harness).
Minimum Jenkins version also updated to to work with the changes.