### PR TITLE
Update required version of waffle-jna

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/negotiatesso-plugin</gitHubRepo>
     <jenkins.version>2.462</jenkins.version>
-    <waffle.version>2.0.0</waffle.version>
+    <waffle.version>2.3.0</waffle.version>
     <jna.version>5.14.0</jna.version><!-- Specified here because jna-platform does need to be the same version as jna -->
   </properties>
 


### PR DESCRIPTION
Update required version of waffle-jna to 2.3.0

Cannot update to 3.x version due to a change in caching, and I cannot figure out how to get the ServiceLoader.load(waffle.util.cache.CacheSupplier) call to succeed (it's supposed to work by default, but something in the Jenkins system ends up ignoring the service specification provided by default in waffle-jna's META-INF/services/ directory and that I tried in that directory for this plugin