### PR TITLE
Remove version number reference from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Only works for Jenkins server on Windows**
 
-A SSO plugin for Jenkins 1.586 and above, running on Windows in a domain environment, using only the built-in Jetty web server. Requests and uses Kerberos or NTLM tickets to authenticate (Uses Windows' Negotiate protocol) 
+A SSO plugin for Jenkins running on Windows in a domain environment, using only the built-in Jetty web server. Requests and uses Kerberos or NTLM tickets to authenticate (Uses Windows' Negotiate protocol)
 
 # Requirements:
 * Jenkins is running as a service
@@ -23,11 +23,11 @@ NOTE: if "Specify custom Active Directory domain name" is used with the Active D
 
 For this plugin to work, Jenkins needs to be running as a service that has permission to perform kerberos authentication, and the system needs to have a domain configuration that allows kerberos authentication. See https://github.com/Waffle/waffle/blob/master/Docs/Troubleshooting.md for some tips on this.
 
-My testing configuration has Jenkins running as hostname\Network Service, with HTTP/hostname and HTTP/hostname.domain SPNs. (NOTE: Previously used hostname\Local System, but changed it to hostname\Network Service for security purposes. Doing so originally broke the jenkins restart, until I edited permissions on the jenkins service using the [Service Security Editor tool] (http://www.coretechnologies.com/products/ServiceSecurityEditor/) to allow Network Service to start/stop/restart the jenkins service.)
+My testing configuration has Jenkins running as hostname\Network Service, with HTTP/hostname and HTTP/hostname.domain SPNs. (NOTE: Previously used hostname\Local System, but changed it to hostname\Network Service for security purposes. Doing so originally broke the jenkins restart, until I edited permissions on the jenkins service using the [Service Security Editor tool](http://www.coretechnologies.com/products/ServiceSecurityEditor/) to allow Network Service to start/stop/restart the jenkins service.)
 
 This uses the Waffle security classes to operate the single sign on, and relies the permissions settings of the Active Directory plugin for user permissions.
 
 As a side note, do not enable impersonation unless every user who has permissions to edit job configurations also has write privileges on the corresponding workspaces...
 
-This started because of I failed to get KerberosSSO working on a Jenkins instance running on a Windows server, and so, apparently, have the creators of KerberosSSO. So I set out to create an extension that did have working SSO for an ActiveDirectory domain.
-This started out heavily based on the KerberosSSO plugin (see https://wiki.jenkins-ci.org/display/JENKINS/Kerberos+SSO+Plugin and https://github.com/jenkinsci/kerberos-sso-plugin), and then suffered the massive changes as I replaced the entire functionality of the extension, as well as how it was implemented (from using Plugin to instead use extension points). However, I have kept some code and duplicated some later changes. There are some licenses (the MIT license) involved with this, and they will be taken care of as I get around to them (and if I have something wrong here, please tell me).
+This started because I failed to get KerberosSSO working on a Jenkins instance running on a Windows server, and so, apparently, have the creators of KerberosSSO. So I set out to create an extension that did have working SSO for an ActiveDirectory domain.
+This started out heavily based on the [KerberosSSO plugin](https://plugins.jenkins.io/kerberos-sso/) ([source code](https://github.com/jenkinsci/kerberos-sso-plugin) ), and then suffered the massive changes as I replaced the entire functionality of the extension, as well as how it was implemented (from using Plugin to instead use extension points). However, I have kept some code and duplicated some later changes. There are some licenses (the MIT license) involved with this, and they will be taken care of as I get around to them (and if I have something wrong here, please tell me).


### PR DESCRIPTION
The version number reference in the README is outdated.  Since the page is commonly read from the [Jenkins plugins site](https://plugins.jenkins.io/NegotiateSSO/) and the plugins site displays the minimum Jenkins version already, it seems reasonable to remove the version number reference from the documentation.

Updates a few hyperlinks to use simpler phrasing and point to current versions of the pages.

### Your checklist for this pull request

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

N/A