### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.12</version><!-- which version of Jenkins plugin pom is this plugin built against? -->
+    <version>5.28</version><!-- which version of Jenkins plugin pom is this plugin built against? -->
     <relativePath />
   </parent>
 
@@ -30,6 +30,7 @@
     <gitHubRepo>jenkinsci/negotiatesso-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed